### PR TITLE
Fixes #1 -  Removed http_error=false option

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,2 @@
+PAYSTACK_SECRET_KEY="your secret key goes here"
+PAYSTACK_SECRET_KEY_FAKE="a fake secret key goes here"

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ vendor
 nbproject
 src/Routes/SkeletonClass.php
 .env
+.idea/

--- a/src/Paystack/Helpers/Router.php
+++ b/src/Paystack/Helpers/Router.php
@@ -134,12 +134,12 @@ class Router
         if ($this->use_guzzle && class_exists('\\GuzzleHttp\\Client') && class_exists('\\GuzzleHttp\\Psr7\\Request')) {
             $request = new \GuzzleHttp\Psr7\Request(strtoupper($method), $endpoint, $headers, $body);
             $client = new \GuzzleHttp\Client();
-            try{
+            try {
                 $response = $client->send($request);
-            }catch(\GuzzleHttp\Exception\RequestException $e){
-                if ($e->hasResponse()){
+            } catch (\GuzzleHttp\Exception\RequestException $e) {
+                if ($e->hasResponse()) {
                     $response = $e->getResponse();
-                }else{
+                } else {
                     $response = null;
                 }
             }

--- a/src/Paystack/Helpers/Router.php
+++ b/src/Paystack/Helpers/Router.php
@@ -3,6 +3,7 @@
 namespace YabaCon\Paystack\Helpers;
 
 use \Closure;
+use Guzzle\Http\Exception\RequestException;
 use \YabaCon\Paystack\Contracts\RouteInterface;
 
 /**
@@ -132,8 +133,16 @@ class Router
     // Use Guzzle if found, else use Curl
         if ($this->use_guzzle && class_exists('\\GuzzleHttp\\Client') && class_exists('\\GuzzleHttp\\Psr7\\Request')) {
             $request = new \GuzzleHttp\Psr7\Request(strtoupper($method), $endpoint, $headers, $body);
-            $client = new \GuzzleHttp\Client(['http_errors' => false]);
-            $response = $client->send($request);
+            $client = new \GuzzleHttp\Client();
+            try{
+                $response = $client->send($request);
+            }catch(\GuzzleHttp\Exception\RequestException $e){
+                if ($e->hasResponse()){
+                    $response = $e->getResponse();
+                }else{
+                    $response = null;
+                }
+            }
             return $response;
             
         } else {

--- a/tests/EndToEndTests.php
+++ b/tests/EndToEndTests.php
@@ -3,11 +3,15 @@
 error_reporting(-1);
 require_once __DIR__ . '/../vendor/autoload.php';
 
-$dotenv = new Dotenv\Dotenv(__DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR);
+$dotenv = new Dotenv\Dotenv(dirname(dirname(__FILE__)));
 $dotenv->load();
 
 $paystack = new \YabaCon\Paystack(getenv("PAYSTACK_SECRET_KEY"));
-//$paystack->useGuzzle();
+
+$paystack2 = new \YabaCon\Paystack(getenv("PAYSTACK_SECRET_KEY_FAKE"));
+$paystack2->useGuzzle();
+$k = $paystack2->customer->list();
+print_r(json_decode($k->getbody(), true));
     
 if (false) {
     print_r($paystack->customer(1));


### PR DESCRIPTION
Merged changes from @crobytech's pull request - fixes #1 

Removed http_error=false option from Guzzle client, on http error when using guzzle, a Guzzle Response object is returned if available else null is returned

Added sample .env file
