### PR TITLE
Typo Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Initialize a transaction by calling our API.
     $paystack = new Yabacon\Paystack(SECRET_KEY);
     try
     {
-      $tranx = $pasytack->transaction->initialize([
+      $tranx = $paystack->transaction->initialize([
         'amount'=>$amount,       // in kobo
         'email'=>$email,         // unique to customers
         'reference'=>$reference, // unique to transactions


### PR DESCRIPTION
There was an error in the second spelling of paystack in the code sample. So the variable was undefined by default once pasted.

## Changes made by this pull request
- Changed a spelling 

